### PR TITLE
feat: helper support for unbalanced pool

### DIFF
--- a/src/contracts/BCoWHelper.sol
+++ b/src/contracts/BCoWHelper.sol
@@ -128,13 +128,20 @@ contract BCoWHelper is ICOWAMMPoolHelper, BMath, BCoWConst {
     uint256 priceDenominator = prices[0];
     uint256 balanceOutTimesWeightIn = bmul(reservesOut.balance, reservesIn.normWeight);
     uint256 balanceInTimesWeightOut = bmul(reservesIn.balance, reservesOut.normWeight);
+
     // This check compares the (weight-adjusted) pool spot price with the input
     // price. The formula for the pool's spot price can be found in the
     // definition of `calcSpotPrice`, assuming no swap fee. The comparison is
     // derived from the following expression:
-    //       priceNumerator     bI / wI      /   bI * wO  \ 
-    //      ---------------- > --------     |  = -------   |
-    //      priceDenominator    bO / wO      \   bO * wI  / 
+    //
+    //       priceNumerator    bO / wO      /   bO * wI  \ 
+    //      ---------------- > -------     |  = -------   |
+    //      priceDenominator   bI / wI      \   bI * wO  /
+    //
+    // This inequality also guarantees that the amount out is positive: the
+    // amount out is positive if and only if this inequality is false, meaning
+    // that if the following condition matches then we want to invert the sell
+    // and buy tokens.
     if (bmul(balanceInTimesWeightOut, priceNumerator) > bmul(balanceOutTimesWeightIn, priceDenominator)) {
       (reservesOut, reservesIn) = (reservesIn, reservesOut);
       (balanceOutTimesWeightIn, balanceInTimesWeightOut) = (balanceInTimesWeightOut, balanceOutTimesWeightIn);

--- a/src/contracts/BCoWHelper.sol
+++ b/src/contracts/BCoWHelper.sol
@@ -129,7 +129,12 @@ contract BCoWHelper is ICOWAMMPoolHelper, BMath, BCoWConst {
     uint256 balanceOutTimesWeightIn = bmul(reservesOut.balance, reservesIn.normWeight);
     uint256 balanceInTimesWeightOut = bmul(reservesIn.balance, reservesOut.normWeight);
     // This check compares the (weight-adjusted) pool spot price with the input
-    // price.
+    // price. The formula for the pool's spot price can be found in the
+    // definition of `calcSpotPrice`, assuming no swap fee. The comparison is
+    // derived from the following expression:
+    //       priceNumerator     bI / wI      /   bI * wO  \ 
+    //      ---------------- > --------     |  = -------   |
+    //      priceDenominator    bO / wO      \   bO * wI  / 
     if (bmul(balanceInTimesWeightOut, priceNumerator) > bmul(balanceOutTimesWeightIn, priceDenominator)) {
       (reservesOut, reservesIn) = (reservesIn, reservesOut);
       (balanceOutTimesWeightIn, balanceInTimesWeightOut) = (balanceInTimesWeightOut, balanceOutTimesWeightIn);

--- a/src/contracts/BCoWHelper.sol
+++ b/src/contracts/BCoWHelper.sol
@@ -118,8 +118,8 @@ contract BCoWHelper is ICOWAMMPoolHelper, BMath, BCoWConst {
     // p  = priceNumerator / priceDenominator
     //
     // Note that in the code we use normalized weights instead of computing the
-    // full expression from raw weights. This is equivalent to assuming that
-    // wI + wO = 1.
+    // full expression from raw weights. Since BCoW pools support only two
+    // tokens, this is equivalent to assuming that wI + wO = 1.
 
     // The price of this function is expressed as amount of token1 per amount
     // of token0. The `prices` vector is expressed the other way around, as

--- a/src/contracts/BCoWHelper.sol
+++ b/src/contracts/BCoWHelper.sol
@@ -5,21 +5,35 @@ import {IBCoWFactory} from 'interfaces/IBCoWFactory.sol';
 import {IBCoWPool} from 'interfaces/IBCoWPool.sol';
 
 import {ICOWAMMPoolHelper} from '@cow-amm/interfaces/ICOWAMMPoolHelper.sol';
-import {GetTradeableOrder} from '@cow-amm/libraries/GetTradeableOrder.sol';
 
 import {IERC20} from '@cowprotocol/interfaces/IERC20.sol';
 import {GPv2Interaction} from '@cowprotocol/libraries/GPv2Interaction.sol';
 import {GPv2Order} from '@cowprotocol/libraries/GPv2Order.sol';
 
-import {BMath} from 'contracts/BMath.sol';
+import {BCoWConst} from './BCoWConst.sol';
+import {BMath} from './BMath.sol';
 
 /**
  * @title BCoWHelper
  * @notice Helper contract that allows to trade on CoW Swap Protocol.
  * @dev This contract supports only 2-token equal-weights pools.
  */
-contract BCoWHelper is ICOWAMMPoolHelper, BMath {
+contract BCoWHelper is ICOWAMMPoolHelper, BMath, BCoWConst {
   using GPv2Order for GPv2Order.Data;
+
+  /**
+   * @dev Collection of pool information on a specific token
+   * @param token The token all fields depend on
+   * @param balance The pool balance for the token
+   * @param denormWeight Denormalized weight of the token
+   * @param normWeight Normalized weight of the token
+   */
+  struct Reserves {
+    IERC20 token;
+    uint256 balance;
+    uint256 denormWeight;
+    uint256 normWeight;
+  }
 
   /// @notice The app data used by this helper's factory.
   bytes32 internal immutable _APP_DATA;
@@ -47,41 +61,7 @@ contract BCoWHelper is ICOWAMMPoolHelper, BMath {
       bytes memory sig
     )
   {
-    address[] memory tokens_ = tokens(pool);
-
-    GetTradeableOrder.GetTradeableOrderParams memory params = GetTradeableOrder.GetTradeableOrderParams({
-      pool: pool,
-      token0: IERC20(tokens_[0]),
-      token1: IERC20(tokens_[1]),
-      // The price of this function is expressed as amount of
-      // token1 per amount of token0. The `prices` vector is
-      // expressed the other way around.
-      priceNumerator: prices[1],
-      priceDenominator: prices[0],
-      appData: _APP_DATA
-    });
-
-    order_ = GetTradeableOrder.getTradeableOrder(params);
-
-    {
-      // NOTE: Using calcOutGivenIn for the sell amount in order to avoid possible rounding
-      // issues that may cause invalid orders. This prevents CoW Protocol back-end from generating
-      // orders that may be ignored due to rounding-induced reverts.
-
-      uint256 balanceToken0 = IERC20(tokens_[0]).balanceOf(pool);
-      uint256 balanceToken1 = IERC20(tokens_[1]).balanceOf(pool);
-      (uint256 balanceIn, uint256 balanceOut) =
-        address(order_.buyToken) == tokens_[0] ? (balanceToken0, balanceToken1) : (balanceToken1, balanceToken0);
-
-      order_.sellAmount = calcOutGivenIn({
-        tokenBalanceIn: balanceIn,
-        tokenWeightIn: 1e18,
-        tokenBalanceOut: balanceOut,
-        tokenWeightOut: 1e18,
-        tokenAmountIn: order_.buyAmount,
-        swapFee: 0
-      });
-    }
+    order_ = _rawOrder(pool, prices);
 
     // A ERC-1271 signature on CoW Protocol is composed of two parts: the
     // signer address and the valid ERC-1271 signature data for that signer.
@@ -117,9 +97,88 @@ contract BCoWHelper is ICOWAMMPoolHelper, BMath {
     if (tokens_.length != 2) {
       revert PoolDoesNotExist();
     }
-    // reverts in case pool is not supported (non-equal weights)
-    if (IBCoWPool(pool).getNormalizedWeight(tokens_[0]) != IBCoWPool(pool).getNormalizedWeight(tokens_[1])) {
-      revert PoolDoesNotExist();
+  }
+
+  /// @notice Returns the order that is suggested to be executed to CoW Protocol
+  /// for a specific pool given the current chain state and final token prices
+  /// @param pool The pool whose funds should be used in the order
+  /// @param prices The prices for each token of the pool
+  /// @return order_ The suggested CoW Protocol order
+  function _rawOrder(address pool, uint256[] calldata prices) internal view returns (GPv2Order.Data memory order_) {
+    address[] memory tokenPair = tokens(pool);
+    Reserves memory reservesOut = _reserves(IBCoWPool(pool), IERC20(tokenPair[0]));
+    Reserves memory reservesIn = _reserves(IBCoWPool(pool), IERC20(tokenPair[1]));
+
+    // The price of this function is expressed as amount of token1 per amount
+    // of token0. The `prices` vector is expressed the other way around, as
+    // confirmed by dimensional analysis of the expression above.
+    uint256 priceNumerator = prices[1]; // x token = sell token = out amount
+    uint256 priceDenominator = prices[0];
+    uint256 balanceOutTimesWeightIn = bmul(reservesOut.balance, reservesIn.normWeight);
+    uint256 balanceInTimesWeightOut = bmul(reservesIn.balance, reservesOut.normWeight);
+    // This check compares the (weight-adjusted) pool spot price with the input
+    // price.
+    if (bmul(balanceInTimesWeightOut, priceNumerator) > bmul(balanceOutTimesWeightIn, priceDenominator)) {
+      (reservesOut, reservesIn) = (reservesIn, reservesOut);
+      (balanceOutTimesWeightIn, balanceInTimesWeightOut) = (balanceInTimesWeightOut, balanceOutTimesWeightIn);
+      (priceNumerator, priceDenominator) = (priceDenominator, priceNumerator);
     }
+    // The out amount is computed according to the following formula:
+    // aO = amountOut
+    // bI = reservesIn.balance                   bO * wI - p * bO * wI
+    // bO = reservesOut.balance            aO =  ---------------------
+    // wI = reservesIn.denormWeight                     wI + wO
+    // wO = reservesOut.denormWeight
+    // p  = priceNumerator / priceDenominator
+    // sF = swapFee
+    uint256 par = bdiv(bmul(balanceInTimesWeightOut, priceNumerator), priceDenominator);
+    uint256 amountOut = balanceOutTimesWeightIn - par;
+    uint256 amountIn = calcInGivenOut({
+      tokenBalanceIn: reservesIn.balance,
+      tokenWeightIn: reservesIn.denormWeight,
+      tokenBalanceOut: reservesOut.balance,
+      tokenWeightOut: reservesOut.denormWeight,
+      tokenAmountOut: amountOut,
+      swapFee: 0
+    });
+
+    // NOTE: Using calcOutGivenIn for the sell amount in order to avoid possible rounding
+    // issues that may cause invalid orders. This prevents CoW Protocol back-end from generating
+    // orders that may be ignored due to rounding-induced reverts.
+    amountOut = calcOutGivenIn({
+      tokenBalanceIn: reservesIn.balance,
+      tokenWeightIn: reservesIn.denormWeight,
+      tokenBalanceOut: reservesOut.balance,
+      tokenWeightOut: reservesOut.denormWeight,
+      tokenAmountIn: amountIn,
+      swapFee: 0
+    });
+    return GPv2Order.Data({
+      sellToken: reservesOut.token,
+      buyToken: reservesIn.token,
+      receiver: GPv2Order.RECEIVER_SAME_AS_OWNER,
+      sellAmount: amountOut,
+      buyAmount: amountIn,
+      validTo: uint32(block.timestamp) + MAX_ORDER_DURATION,
+      appData: _APP_DATA,
+      feeAmount: 0,
+      kind: GPv2Order.KIND_SELL,
+      partiallyFillable: true,
+      sellTokenBalance: GPv2Order.BALANCE_ERC20,
+      buyTokenBalance: GPv2Order.BALANCE_ERC20
+    });
+  }
+
+  /// @notice Returns information on pool reserves for a specific pool and token
+  /// @dev This is mostly used for the readability of grouping all parameters
+  /// relative to the same token are grouped together in the same variable
+  /// @param pool The pool with the funds
+  /// @param token The token on which to recover information
+  /// @return Parameters relative to the token reserves in the pool
+  function _reserves(IBCoWPool pool, IERC20 token) internal view returns (Reserves memory) {
+    uint256 balance = token.balanceOf(address(pool));
+    uint256 normalizedWeight = pool.getNormalizedWeight(address(token));
+    uint256 denormalizedWeight = pool.getDenormalizedWeight(address(token));
+    return Reserves({token: token, balance: balance, denormWeight: denormalizedWeight, normWeight: normalizedWeight});
   }
 }

--- a/src/contracts/BCoWHelper.sol
+++ b/src/contracts/BCoWHelper.sol
@@ -16,7 +16,7 @@ import {BMath} from './BMath.sol';
 /**
  * @title BCoWHelper
  * @notice Helper contract that allows to trade on CoW Swap Protocol.
- * @dev This contract supports only 2-token equal-weights pools.
+ * @dev This contract supports only 2-token pools.
  */
 contract BCoWHelper is ICOWAMMPoolHelper, BMath, BCoWConst {
   using GPv2Order for GPv2Order.Data;

--- a/src/contracts/BCoWHelper.sol
+++ b/src/contracts/BCoWHelper.sol
@@ -125,7 +125,7 @@ contract BCoWHelper is ICOWAMMPoolHelper, BMath, BCoWConst {
     }
     // The out amount is computed according to the following formula:
     // aO = amountOut
-    // bI = reservesIn.balance                   bO * wI - p * bO * wI
+    // bI = reservesIn.balance                   bO * wI - p * bI * wO
     // bO = reservesOut.balance            aO =  ---------------------
     // wI = reservesIn.denormWeight                     wI + wO
     // wO = reservesOut.denormWeight

--- a/test/integration/BCoWHelper.t.sol
+++ b/test/integration/BCoWHelper.t.sol
@@ -43,8 +43,8 @@ contract BCoWHelperIntegrationTest is Test {
   uint256 constant TEN_PERCENT = 0.1 ether;
   uint256 constant ONE_IN_A_BILLION = 0.000000001 ether;
   // NOTE: 1 ETH = 1000 DAI
-  uint256 constant EQUAL_WEIGTH_INITIAL_DAI_BALANCE = 1000 ether;
-  uint256 constant EQUAL_WEIGTH_INITIAL_WETH_BALANCE = 1 ether;
+  uint256 constant EQUAL_WEIGHT_INITIAL_DAI_BALANCE = 1000 ether;
+  uint256 constant EQUAL_WEIGHT_INITIAL_WETH_BALANCE = 1 ether;
   uint256 constant INITIAL_SPOT_PRICE = 0.001e18;
 
   uint256 constant SKEWENESS_RATIO = 95; // -5% skewness
@@ -70,14 +70,14 @@ contract BCoWHelperIntegrationTest is Test {
 
     DAI.approve(address(basicPool), type(uint256).max);
     WETH.approve(address(basicPool), type(uint256).max);
-    basicPool.bind(address(DAI), EQUAL_WEIGTH_INITIAL_DAI_BALANCE, 4.2e18); // no weight
-    basicPool.bind(address(WETH), EQUAL_WEIGTH_INITIAL_WETH_BALANCE, 4.2e18); // no weight
+    basicPool.bind(address(DAI), EQUAL_WEIGHT_INITIAL_DAI_BALANCE, 4.2e18); // no weight
+    basicPool.bind(address(WETH), EQUAL_WEIGHT_INITIAL_WETH_BALANCE, 4.2e18); // no weight
 
     DAI.approve(address(weightedPool), type(uint256).max);
     WETH.approve(address(weightedPool), type(uint256).max);
     // NOTE: pool is 80-20 DAI-WETH, has 4xDAI balance than basic, same spot price
-    weightedPool.bind(address(DAI), 4 * EQUAL_WEIGTH_INITIAL_DAI_BALANCE, 8e18); // 80% weight
-    weightedPool.bind(address(WETH), EQUAL_WEIGTH_INITIAL_WETH_BALANCE, 2e18); // 20% weight
+    weightedPool.bind(address(DAI), 4 * EQUAL_WEIGHT_INITIAL_DAI_BALANCE, 8e18); // 80% weight
+    weightedPool.bind(address(WETH), EQUAL_WEIGHT_INITIAL_WETH_BALANCE, 2e18); // 20% weight
 
     // finalize
     basicPool.finalize();
@@ -128,8 +128,8 @@ contract BCoWHelperIntegrationTest is Test {
     // if the first token is DAI and the second WETH then a price of 3000
     // DAI per WETH means a price vector of [1, 3000] (if the decimals are
     // different, as in WETH/USDC, then the atom amount is what counts).
-    prices[daiIndex] = EQUAL_WEIGTH_INITIAL_WETH_BALANCE;
-    prices[wethIndex] = EQUAL_WEIGTH_INITIAL_DAI_BALANCE * SKEWENESS_RATIO / 100;
+    prices[daiIndex] = EQUAL_WEIGHT_INITIAL_WETH_BALANCE;
+    prices[wethIndex] = EQUAL_WEIGHT_INITIAL_DAI_BALANCE * SKEWENESS_RATIO / 100;
 
     // The helper generates the AMM order
     GPv2Order.Data memory ammOrder;

--- a/test/manual-smock/MockBCoWHelper.sol
+++ b/test/manual-smock/MockBCoWHelper.sol
@@ -6,7 +6,6 @@ import {
   BMath,
   GPv2Interaction,
   GPv2Order,
-  GetTradeableOrder,
   IBCoWFactory,
   IBCoWPool,
   ICOWAMMPoolHelper,

--- a/test/unit/BCoWHelper.tree
+++ b/test/unit/BCoWHelper.tree
@@ -10,9 +10,9 @@ BCoWHelperTest::tokens
 │   └── it should revert
 ├── when pool has more than 2 tokens
 │   └── it should revert
-├── when pool tokens have different weights
-│   └── it should revert
-└── when pool is supported
+├── when pool with equal weights is supported
+│   └── it should return pool tokens
+└── when pool with different weights is supported
     └── it should return pool tokens
 
 BCoWHelperTest::order


### PR DESCRIPTION
These changes make the helper support two-token pools with arbitrary weights.

More discussion on the math can be found [here](https://cowservices.slack.com/archives/C035TDPHQAJ/p1719567592184189?thread_ts=1719410711.653979&cid=C035TDPHQAJ) (I hope this link works for your team!). Message content copied below for accessibility.

More details are available as inline comments.

Notably, the `GetTradeableOrder` library is not needed anymore, since the math is now specific to this AMM version.

### How to test

Unit/integration tests have been changed to account for the new pool format. Logic changes are needed because the definition of the spot price isn't just the rate of the two pool balances when the weights are different.

Note that the "unreasonable amount" check has been removed. This is because it's hard to succinctly come up with a reasonableness check that works for both equal-weight and distinct-weight pool and is menaningfully readable. I don't think this is an issue since in both tests involving this check we also verify that the final price of the AMM coincides with `EXPECTED_FINAL_SPOT_PRICE`, which is reasonable by construction.

Some steps on CI are still expected to fail because:
- `secrets.MAINNET_RPC` doesn't appear to have been set (see [here](https://github.com/fedgiac/balancer-cow-amm/actions/runs/10769039841/job/29860298059) to confirm that the integration tests work)
- A Foundry update has changed the behavior of the default formatter. Fixing formatting would require changing many unrelated contracts, so I kept the old formatting in this PR.

<details><summary>Message with rationale for the math.</summary>

you want to calculate the sell amount so that, if the AMM sells tokens at the oracle price then its spot price equals the oracle price. So, if the oracle price is p, and you start with `b_x/w_x>p b_y/w_y`, you want to sell x for x/p such that

```
(b_x-x)/w_x=p (b_y+x/p)/w_y .
```

To put it another way, the calculations are correct if, in the end, the AMM spot price equals the Oracle. Also, the calculations have nothing to do with the "buy amount."

To conclude the calculations: you can solve the equation and get:

```
x = (w_x * w_y/(w_x+w_y))*(b_x/w_x - P (b_y/w_y))
```

note that the formula as in the reference implementation is

```
x = (b_x/2 - P (b_y/2))
```

so if you want to recycle it you need to normalize `w_x+w_y=2`  and redefine the pool reserves as  `b_x*w_y`  and `b_y*w_x`.
Then, once the calculations for the sell amount are correct, you just put its value in the `inGivenOut` formula to get the "buyAmount"

</details>