### PR TITLE
feat: helper support for orders with arbitrary amounts

### DIFF
--- a/src/contracts/BCoWHelper.sol
+++ b/src/contracts/BCoWHelper.sol
@@ -42,6 +42,9 @@ contract BCoWHelper is ICOWAMMPoolHelper, BMath, BCoWConst {
   // solhint-disable-next-line style-guide-casing
   address public immutable factory;
 
+  /// @notice The input token to the call is not traded on the pool.
+  error InvalidToken();
+
   constructor(address factory_) {
     factory = factory_;
     _APP_DATA = IBCoWFactory(factory_).APP_DATA();
@@ -61,26 +64,89 @@ contract BCoWHelper is ICOWAMMPoolHelper, BMath, BCoWConst {
       bytes memory sig
     )
   {
-    order_ = _rawOrder(pool, prices);
+    address[] memory tokenPair = tokens(pool);
+    Reserves memory reservesToken0 = _reserves(IBCoWPool(pool), IERC20(tokenPair[0]));
+    Reserves memory reservesToken1 = _reserves(IBCoWPool(pool), IERC20(tokenPair[1]));
 
-    // A ERC-1271 signature on CoW Protocol is composed of two parts: the
-    // signer address and the valid ERC-1271 signature data for that signer.
-    bytes memory eip1271sig;
-    eip1271sig = abi.encode(order_);
-    sig = abi.encodePacked(pool, eip1271sig);
+    (Reserves memory reservesIn, uint256 amountIn, Reserves memory reservesOut) =
+      _amountInFromPrices(reservesToken0, reservesToken1, prices);
 
-    // Generate the order commitment pre-interaction
-    bytes32 domainSeparator = IBCoWPool(pool).SOLUTION_SETTLER_DOMAIN_SEPARATOR();
-    bytes32 orderCommitment = order_.hash(domainSeparator);
+    return _orderFromBuyAmount(pool, reservesIn, amountIn, reservesOut);
+  }
 
-    preInteractions = new GPv2Interaction.Data[](1);
-    preInteractions[0] = GPv2Interaction.Data({
-      target: pool,
-      value: 0,
-      callData: abi.encodeWithSelector(IBCoWPool.commit.selector, orderCommitment)
+  /// @notice Method for returning the canonical order required to satisfy the
+  /// pool's invariants, given a buy token and exact buy amount.
+  /// @param pool Pool to calculate the order / signature for
+  /// @param buyToken The address used in the resulting order as the buy token
+  /// @param buyAmount The exact buy amount used in the resulting order
+  /// @return order_ The CoW Protocol JIT order
+  /// @return preInteractions The array array for any **PRE** interactions(empty if none)
+  /// @return postInteractions The array array for any **POST** interactions (empty if none)
+  /// @return sig A valid CoW-Protocol signature for the resulting order using
+  /// the ERC-1271 signature scheme.
+  function orderFromBuyAmount(
+    address pool,
+    address buyToken,
+    uint256 buyAmount
+  )
+    external
+    view
+    returns (
+      GPv2Order.Data memory order_,
+      GPv2Interaction.Data[] memory preInteractions,
+      GPv2Interaction.Data[] memory postInteractions,
+      bytes memory sig
+    )
+  {
+    address tokenIn = buyToken;
+    address tokenOut = _otherTokenInPair(pool, tokenIn);
+    Reserves memory reservesIn = _reserves(IBCoWPool(pool), IERC20(tokenIn));
+    Reserves memory reservesOut = _reserves(IBCoWPool(pool), IERC20(tokenOut));
+
+    return _orderFromBuyAmount(pool, reservesIn, buyAmount, reservesOut);
+  }
+
+  /// @notice Method for returning the canonical order required to satisfy the
+  /// pool's invariants, given a sell token and a **tentative** sell amount.
+  /// The sell amount of the resulting order will not exactly be the input sell
+  /// amount, however it should be fairly close for typical pool configurations.
+  /// @param pool Pool to calculate the order / signature for
+  /// @param sellToken The address used in the resulting order as the sell token
+  /// @param sellAmount The **tentative** sell amount used in the resulting order
+  /// @return order_ The CoW Protocol JIT order
+  /// @return preInteractions The array array for any **PRE** interactions (empty if none)
+  /// @return postInteractions The array array for any **POST** interactions (empty if none)
+  /// @return sig A valid CoW-Protocol signature for the resulting order using
+  /// the ERC-1271 signature scheme.
+  function orderFromSellAmount(
+    address pool,
+    address sellToken,
+    uint256 sellAmount
+  )
+    external
+    view
+    returns (
+      GPv2Order.Data memory order_,
+      GPv2Interaction.Data[] memory preInteractions,
+      GPv2Interaction.Data[] memory postInteractions,
+      bytes memory sig
+    )
+  {
+    address tokenOut = sellToken;
+    address tokenIn = _otherTokenInPair(pool, tokenOut);
+
+    Reserves memory reservesIn = _reserves(IBCoWPool(pool), IERC20(tokenIn));
+    Reserves memory reservesOut = _reserves(IBCoWPool(pool), IERC20(tokenOut));
+
+    uint256 amountIn = calcInGivenOut({
+      tokenBalanceIn: reservesIn.balance,
+      tokenWeightIn: reservesIn.denormWeight,
+      tokenBalanceOut: reservesOut.balance,
+      tokenWeightOut: reservesOut.denormWeight,
+      tokenAmountOut: sellAmount,
+      swapFee: 0
     });
-
-    return (order_, preInteractions, postInteractions, sig);
+    return _orderFromBuyAmount(pool, reservesIn, amountIn, reservesOut);
   }
 
   /// @inheritdoc ICOWAMMPoolHelper
@@ -99,15 +165,135 @@ contract BCoWHelper is ICOWAMMPoolHelper, BMath, BCoWConst {
     }
   }
 
+  /// @notice Helper method to compute the output of `orderFromBuyAmount`.
+  /// @param pool Pool to calculate the order / signature for
+  /// @param reservesIn Details for the input token to the pool
+  /// @param amountIn Token amount moving into the pool for this order
+  /// @param reservesOut Details for the output token to the pool
+  /// @return order_ The CoW Protocol JIT order
+  /// @return preInteractions The array array for any **PRE** interactions (empty if none)
+  /// @return postInteractions The array array for any **POST** interactions (empty if none)
+  /// @return sig A valid CoW-Protocol signature for the resulting order using
+  /// the ERC-1271 signature scheme.
+  function _orderFromBuyAmount(
+    address pool,
+    Reserves memory reservesIn,
+    uint256 amountIn,
+    Reserves memory reservesOut
+  )
+    internal
+    view
+    returns (
+      GPv2Order.Data memory order_,
+      GPv2Interaction.Data[] memory preInteractions,
+      GPv2Interaction.Data[] memory postInteractions,
+      bytes memory sig
+    )
+  {
+    order_ = _rawOrderFrom(reservesIn, amountIn, reservesOut);
+    (preInteractions, postInteractions, sig) = _prepareSettlement(pool, order_);
+  }
+
+  /// @notice Helper method to compute interactions and signature for the input
+  /// CoW Protocol JIT order.
+  /// @param pool Pool to calculate the interactions / signature for
+  /// @param order_ The CoW Protocol JIT order
+  /// @return preInteractions The array array for any **PRE** interactions (empty if none)
+  /// @return postInteractions The array array for any **POST** interactions (empty if none)
+  /// @return sig A valid CoW-Protocol signature for the resulting order using
+  /// the ERC-1271 signature scheme.
+  function _prepareSettlement(
+    address pool,
+    GPv2Order.Data memory order_
+  )
+    internal
+    view
+    returns (
+      GPv2Interaction.Data[] memory preInteractions,
+      GPv2Interaction.Data[] memory postInteractions,
+      bytes memory sig
+    )
+  {
+    // A ERC-1271 signature on CoW Protocol is composed of two parts: the
+    // signer address and the valid ERC-1271 signature data for that signer.
+    bytes memory eip1271sig;
+    eip1271sig = abi.encode(order_);
+    sig = abi.encodePacked(pool, eip1271sig);
+
+    // Generate the order commitment pre-interaction
+    bytes32 domainSeparator = IBCoWPool(pool).SOLUTION_SETTLER_DOMAIN_SEPARATOR();
+    bytes32 orderCommitment = order_.hash(domainSeparator);
+
+    preInteractions = new GPv2Interaction.Data[](1);
+    preInteractions[0] = GPv2Interaction.Data({
+      target: pool,
+      value: 0,
+      callData: abi.encodeWithSelector(IBCoWPool.commit.selector, orderCommitment)
+    });
+
+    return (preInteractions, postInteractions, sig);
+  }
+
   /// @notice Returns the order that is suggested to be executed to CoW Protocol
-  /// for a specific pool given the current chain state and final token prices
-  /// @param pool The pool whose funds should be used in the order
-  /// @param prices The prices for each token of the pool
-  /// @return order_ The suggested CoW Protocol order
-  function _rawOrder(address pool, uint256[] calldata prices) internal view returns (GPv2Order.Data memory order_) {
-    address[] memory tokenPair = tokens(pool);
-    Reserves memory reservesOut = _reserves(IBCoWPool(pool), IERC20(tokenPair[0]));
-    Reserves memory reservesIn = _reserves(IBCoWPool(pool), IERC20(tokenPair[1]));
+  /// for specific reserves of a pool given the current chain state and the
+  /// traded amount. The price of the order is on the AMM curve for the traded
+  /// amount.
+  /// @dev This function takes an input amount and guarantees that the final
+  /// order has that input amount and is a valid order. We use `calcOutGivenIn`
+  /// to compute the output amount as this is the function used to check that
+  /// the CoW Swap order is valid in the contract. It would not be possible to
+  /// just define the same function by specifying an output amount and use
+  /// `calcInGiveOut`: because of rounding issues the resulting order could be
+  /// invalid.
+  /// @param reservesIn Data related to the input token of this trade
+  /// @param amountIn Token amount moving into the pool for this order
+  /// @param reservesOut Data related to the output token of this trade
+  /// @return order_ The CoW Protocol JIT order
+  function _rawOrderFrom(
+    Reserves memory reservesIn,
+    uint256 amountIn,
+    Reserves memory reservesOut
+  ) internal view returns (GPv2Order.Data memory order_) {
+    uint256 amountOut = calcOutGivenIn({
+      tokenBalanceIn: reservesIn.balance,
+      tokenWeightIn: reservesIn.denormWeight,
+      tokenBalanceOut: reservesOut.balance,
+      tokenWeightOut: reservesOut.denormWeight,
+      tokenAmountIn: amountIn,
+      swapFee: 0
+    });
+    return GPv2Order.Data({
+      sellToken: reservesOut.token,
+      buyToken: reservesIn.token,
+      receiver: GPv2Order.RECEIVER_SAME_AS_OWNER,
+      sellAmount: amountOut,
+      buyAmount: amountIn,
+      validTo: uint32(block.timestamp) + MAX_ORDER_DURATION,
+      appData: _APP_DATA,
+      feeAmount: 0,
+      kind: GPv2Order.KIND_SELL,
+      partiallyFillable: true,
+      sellTokenBalance: GPv2Order.BALANCE_ERC20,
+      buyTokenBalance: GPv2Order.BALANCE_ERC20
+    });
+  }
+
+  /// @notice Returns which trade is suggested to be executed on CoW Protocol
+  /// for specific reserves of a pool given the current chain state and prices
+  /// @param reservesToken0 Data related to the first token traded in the pool
+  /// @param reservesToken1 Data related to the second token traded in the pool
+  /// @param prices supplied for determining the order; the format is specified
+  /// in the `order` function
+  /// @return reservesIn Data related to the input token in the trade
+  /// @return amountIn How much input token should be trated
+  /// @return reservesOut Data related to the input token in the trade
+  function _amountInFromPrices(
+    Reserves memory reservesToken0,
+    Reserves memory reservesToken1,
+    uint256[] calldata prices
+  ) internal view returns (Reserves memory reservesIn, uint256 amountIn, Reserves memory reservesOut) {
+    reservesOut = reservesToken0;
+    reservesIn = reservesToken1;
 
     // The out amount is computed according to the following formula:
     // aO = amountOut
@@ -134,7 +320,7 @@ contract BCoWHelper is ICOWAMMPoolHelper, BMath, BCoWConst {
     // definition of `calcSpotPrice`, assuming no swap fee. The comparison is
     // derived from the following expression:
     //
-    //       priceNumerator    bO / wO      /   bO * wI  \ 
+    //       priceNumerator    bO / wO      /   bO * wI  \
     //      ---------------- > -------     |  = -------   |
     //      priceDenominator   bI / wI      \   bI * wO  /
     //
@@ -149,39 +335,13 @@ contract BCoWHelper is ICOWAMMPoolHelper, BMath, BCoWConst {
     }
     uint256 par = bdiv(bmul(balanceInTimesWeightOut, priceNumerator), priceDenominator);
     uint256 amountOut = balanceOutTimesWeightIn - par;
-    uint256 amountIn = calcInGivenOut({
+    amountIn = calcInGivenOut({
       tokenBalanceIn: reservesIn.balance,
       tokenWeightIn: reservesIn.denormWeight,
       tokenBalanceOut: reservesOut.balance,
       tokenWeightOut: reservesOut.denormWeight,
       tokenAmountOut: amountOut,
       swapFee: 0
-    });
-
-    // NOTE: Using calcOutGivenIn for the sell amount in order to avoid possible rounding
-    // issues that may cause invalid orders. This prevents CoW Protocol back-end from generating
-    // orders that may be ignored due to rounding-induced reverts.
-    amountOut = calcOutGivenIn({
-      tokenBalanceIn: reservesIn.balance,
-      tokenWeightIn: reservesIn.denormWeight,
-      tokenBalanceOut: reservesOut.balance,
-      tokenWeightOut: reservesOut.denormWeight,
-      tokenAmountIn: amountIn,
-      swapFee: 0
-    });
-    return GPv2Order.Data({
-      sellToken: reservesOut.token,
-      buyToken: reservesIn.token,
-      receiver: GPv2Order.RECEIVER_SAME_AS_OWNER,
-      sellAmount: amountOut,
-      buyAmount: amountIn,
-      validTo: uint32(block.timestamp) + MAX_ORDER_DURATION,
-      appData: _APP_DATA,
-      feeAmount: 0,
-      kind: GPv2Order.KIND_SELL,
-      partiallyFillable: true,
-      sellTokenBalance: GPv2Order.BALANCE_ERC20,
-      buyTokenBalance: GPv2Order.BALANCE_ERC20
     });
   }
 
@@ -196,5 +356,23 @@ contract BCoWHelper is ICOWAMMPoolHelper, BMath, BCoWConst {
     uint256 normalizedWeight = pool.getNormalizedWeight(address(token));
     uint256 denormalizedWeight = pool.getDenormalizedWeight(address(token));
     return Reserves({token: token, balance: balance, denormWeight: denormalizedWeight, normWeight: normalizedWeight});
+  }
+
+  /// @notice For a two-token pool, this method takes one of the two traded
+  /// tokens and returns the other.
+  /// If the token is not traded in the pool, this function reverts.
+  /// @param pool Two-token pool supporting the tokens
+  /// @param token A token that is supported by the pool
+  /// @return otherToken The other token supported by the two-token pool
+  function _otherTokenInPair(address pool, address token) internal view returns (address otherToken) {
+    address[] memory tokenPair = tokens(pool);
+
+    if (tokenPair[0] == token) {
+      otherToken = tokenPair[1];
+    } else if (tokenPair[1] == token) {
+      otherToken = tokenPair[0];
+    } else {
+      revert InvalidToken();
+    }
   }
 }

--- a/test/unit/BCoWHelper.tree
+++ b/test/unit/BCoWHelper.tree
@@ -31,3 +31,33 @@ BCoWHelperTest::order
 └── given a price skeweness to token0
     ├── it should buy token1
     └── it should return a valid pool order
+
+BCoWHelperTest::orderFromSellAmount
+├── when the pool is not supported
+│   └── it should revert
+├── when the token is not traded
+│   └── it should revert
+└── when the pool is supported
+    ├── it should support selling both token0 or token1
+    ├── it should return a valid pool order
+    ├── it should set expected buy and sell tokens
+    ├── it should approximately match the input sell amount
+    ├── it should have the highest tradable sell amount
+    ├── it should return a commit pre-interaction
+    ├── it should return an empty post-interaction
+    └── it should return a valid signature
+
+BCoWHelperTest::orderFromBuyAmount
+├── when the pool is not supported
+│   └── it should revert
+├── when the token is not traded
+│   └── it should revert
+└── when the pool is supported
+    ├── it should support buying both token0 or token1
+    ├── it should return a valid pool order
+    ├── it should set expected buy and sell tokens
+    ├── it should exactly match the input buy amount
+    ├── it should have the highest tradable sell amount
+    ├── it should return a commit pre-interaction
+    ├── it should return an empty post-interaction
+    └── it should return a valid signature


### PR DESCRIPTION
These changes add two features to the CoW AMM helper that allow solvers to create valid AMM orders given (1) the token they want to sell or buy and (2) the amount. This is intended to make integrations by solvers with CoW AMMs easier.

Concretely, it introduces the following two functions in the helper:
- `orderFromBuyAmount(address pool, address buyToken, uint256 buyAmount)`
- `orderFromSellAmount(address pool, address sellToken, uint256 sellAmount)`

They both have the same output of the existing `order` function.
In fact, the code of `order` has been changed to use the price vector to generate the token and traded amount and then fall back to the same code used in the newly introduced functions. Most of the existing code has been reused, however there are many changes because some steps have been moved to their own dedicated function.

There is a noticeable difference in the behavior of the two new functions. `orderFromBuyAmount` is guaranteed to generate an order with buy amount coinciding with the input buy amount. However, `orderFromSellAmount` will generate a sell amount whose order sell amount is _only approximately_ the same as the input sell amount, but it can differ significantly on extreme choices of weights and pool parameters.
The root cause of this is that (1) the CoW-Protocol order verification function is based on the output of `calcOutGivenIn` only and (2) `calcOutGivenIn` and `calcInGivenOut` are not one the inverse of the other, especially if the parameters are outside "reasonable" ranges for the pool. Just relying on `calcInGivenOut` means that hard-to-bound rounding errors would cause the generated order to be invalid for the verification function.
While the code here could be improved with more specific math to account for rounding, for now we want to explore the impact of the new helper functions on solvers and we'd rater rely on approximately similar output.

### How to test

New unit tests have been introduced. They follow the same pattern used in the existing tests for the `order` function.

Some steps on CI are still expected to fail because:

- `secrets.MAINNET_RPC` doesn't appear to have been set (see [here](https://github.com/fedgiac/balancer-cow-amm/actions/runs/11130975666/job/30931504305) to confirm that integration tests still work)
- A Foundry update has changed the behavior of the default formatter. Fixing formatting would require changing many unrelated contracts, so I kept the old formatting in this PR.